### PR TITLE
ts/enable-rewards

### DIFF
--- a/Api/RewardServiceInterface.php
+++ b/Api/RewardServiceInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Instant\Checkout\Api;
+
+use Magento\Customer\Api\Data\CustomerInterface;
+use Magento\Quote\Api\Data\CartInterface;
+
+/**
+ * Interface RewardServiceInterface
+ */
+interface RewardServiceInterface
+{
+    /**
+     * Get the reward points balance for a customer.
+     *
+     * @param CustomerInterface $customer
+     * @return int
+     */
+    public function getRewardPointsBalance(CustomerInterface $customer): int;
+
+    /**
+     * Apply reward points to a quote.
+     *
+     * @param int $points
+     * @param CartInterface $quote
+     * @param CustomerInterface $customer
+     * @return void
+     */
+    public function applyRewardPointsToQuote(int $points, CartInterface $quote, CustomerInterface $customer);
+}

--- a/Api/RewardServiceInterface.php
+++ b/Api/RewardServiceInterface.php
@@ -13,18 +13,17 @@ interface RewardServiceInterface
     /**
      * Get the reward points balance for a customer.
      *
-     * @param CustomerInterface $customer
+     * @param int $customerId
      * @return int
      */
-    public function getRewardPointsBalance(CustomerInterface $customer): int;
+    public function getRewardPointsBalance(int $customerId): int;
 
     /**
      * Apply reward points to a quote.
      *
-     * @param int $points
      * @param CartInterface $quote
-     * @param CustomerInterface $customer
+     * @param int $customerId
      * @return void
      */
-    public function applyRewardPointsToQuote(int $points, CartInterface $quote, CustomerInterface $customer);
+    public function applyRewardPointsToQuote(CartInterface $quote, int $customerId);
 }

--- a/Service/RewardService.php
+++ b/Service/RewardService.php
@@ -113,6 +113,7 @@ class RewardService implements RewardServiceInterface
 	protected function convertPointsToAmount($points)
     {
         // Retrieve the points conversion rate from the Magento configuration
+        // TO-DO: Verify this path (reward/general/points_money) is correct once we have access to the dev environment. 
         $pointsValue = $this->scopeConfig->getValue(
             'reward/general/points_money',
             ScopeInterface::SCOPE_STORE

--- a/Service/RewardService.php
+++ b/Service/RewardService.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Instant\Checkout\Model;
+
+use Magento\Framework\Exception\LocalizedException;
+use Instant\Checkout\Api\RewardServiceInterface;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Store\Model\ScopeInterface;
+use Magento\Customer\Api\Data\CustomerInterface;
+use Magento\Quote\Api\Data\CartInterface;
+use Magento\Reward\Model\RewardFactory;
+use Psr\Log\LoggerInterface;
+
+class RewardService implements RewardServiceInterface
+{
+    /**
+     * @var RewardFactory
+     */
+    protected $rewardFactory;
+
+    /**
+     * @var LoggerInterface
+     */
+    protected $logger;
+	
+	/**
+     * @var ScopeConfigInterface
+     */
+    protected $scopeConfig;
+
+    /**
+     * RewardService constructor.
+     *
+     * @param RewardFactory $rewardFactory
+     * @param LoggerInterface $logger
+	 * @param ScopeConfigInterface $scopeConfig
+     */
+    public function __construct(
+        RewardFactory $rewardFactory,
+        LoggerInterface $logger,
+		ScopeConfigInterface $scopeConfig
+    ) {
+        $this->rewardFactory = $rewardFactory;
+        $this->logger = $logger;
+		$this->scopeConfig = $scopeConfig;
+    }
+
+    /**
+     * Get the reward points balance for a customer.
+     *
+     * @param CustomerInterface $customer
+     * @return int
+     */
+    public function getRewardPointsBalance(CustomerInterface $customer)
+    {
+        try {
+            /** @var Reward $reward */
+            $reward = $this->rewardFactory->create();
+            $reward->setCustomer($customer);
+            $reward->setWebsiteId($customer->getWebsiteId());
+            $reward->loadByCustomer();
+
+            $pointsBalance = $reward->getPointsBalance();
+            $this->logInfo('Reward points balance for customer ' . $customer->getId() . ': ' . $pointsBalance);
+
+            return $pointsBalance;
+        } catch (Exception $e) {
+            $this->logError('Error retrieving reward points balance: ' . $e->getMessage());
+            return 0;
+        }
+    }
+
+    /**
+     * Apply reward points to a quote.
+     *
+     * @param int $points
+     * @param CartInterface $quote
+     * @param CustomerInterface $customer
+     * @return void
+     */
+	public function applyRewardPointsToQuote($points, CartInterface $quote, CustomerInterface $customer)
+	{
+		try {
+			$this->logInfo('Applying ' . $points . ' reward points to quote ' . $quote->getId() . ' for customer ' . $customer->getId());
+	
+			// Check if the customer has enough reward points
+			$availablePoints = $this->getRewardPointsBalance($customer);
+			if ($points > $availablePoints) {
+				throw new \Magento\Framework\Exception\LocalizedException(__('Insufficient reward points.'));
+			}
+	
+			// Convert reward points to currency amount
+			$rewardAmount = $this->convertPointsToAmount($points);
+	
+			// Apply the reward amount to the quote
+			$quote->setUseRewardPoints(true);
+			$quote->setRewardPointsBalance($availablePoints);
+			$quote->setRewardCurrencyAmount($rewardAmount);
+			$quote->setBaseRewardCurrencyAmount($rewardAmount);
+			$quote->collectTotals();
+	
+			// Save the quote
+			$quote->save();
+	
+			$this->logInfo('Successfully applied ' . $points . ' reward points to quote ' . $quote->getId());
+		} catch (Exception $e) {
+			$this->logError('Error applying reward points to quote: ' . $e->getMessage());
+			throw new \Magento\Framework\Exception\LocalizedException(__('Could not apply reward points to the quote.'));
+		}
+	}
+	
+	protected function convertPointsToAmount($points)
+    {
+        // Retrieve the points conversion rate from the Magento configuration
+        $pointsValue = $this->scopeConfig->getValue(
+            'reward/general/points_money',
+            ScopeInterface::SCOPE_STORE
+        );
+
+        // Convert reward points to currency amount
+        $amount = $points / $pointsValue;
+        return $amount;
+    }
+	
+    /**
+     * Log an info message.
+     *
+     * @param string $message
+     */
+    protected function logInfo($message)
+    {
+        $this->logger->info('[INSTANT]: ' . $message);
+    }
+
+    /**
+     * Log an error message.
+     *
+     * @param string $message
+     */
+    protected function logError($message)
+    {
+        $this->logger->error('[INSTANT]: ' . $message);
+    }
+}

--- a/Service/RewardService.php
+++ b/Service/RewardService.php
@@ -5,9 +5,8 @@ namespace Instant\Checkout\Service;
 use Exception;
 use Magento\Framework\Exception\LocalizedException;
 use Instant\Checkout\Api\RewardServiceInterface;
-use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Customer\Api\CustomerRepositoryInterface;
 use Magento\Store\Model\ScopeInterface;
-use Magento\Customer\Api\Data\CustomerInterface;
 use Magento\Quote\Api\Data\CartInterface;
 use Magento\Reward\Model\RewardFactory;
 use Psr\Log\LoggerInterface;
@@ -28,6 +27,11 @@ class RewardService implements RewardServiceInterface
      * @var ScopeConfigInterface
      */
     protected $scopeConfig;
+    
+	/**
+     * @var CustomerRepositoryInterface
+     */
+    protected $customerRepository;
 
     /**
      * RewardService constructor.
@@ -35,27 +39,33 @@ class RewardService implements RewardServiceInterface
      * @param RewardFactory $rewardFactory
      * @param LoggerInterface $logger
 	 * @param ScopeConfigInterface $scopeConfig
+	 * @param CustomerRepositoryInterface $customerRepository
      */
     public function __construct(
         RewardFactory $rewardFactory,
         LoggerInterface $logger,
-		ScopeConfigInterface $scopeConfig
+		ScopeConfigInterface $scopeConfig,
+		CustomerRepositoryInterface $customerRepository
     ) {
         $this->rewardFactory = $rewardFactory;
         $this->logger = $logger;
 		$this->scopeConfig = $scopeConfig;
+		$this->customerRepository = $customerRepository;
     }
 
     /**
      * Get the reward points balance for a customer.
      *
-     * @param CustomerInterface $customer
+     * @param int $customerId
      * @return int
      */
-    public function getRewardPointsBalance(CustomerInterface $customer)
+    public function getRewardPointsBalance(int $customerId)
     {
         try {
-            /** @var Reward $reward */
+            // Retrieve the customer object by customerId
+            $customer = $this->customerRepository->getById($customerId);
+            
+            /** @var \Magento\Reward\Model\RewardFactory $reward */
             $reward = $this->rewardFactory->create();
             $reward->setCustomer($customer);
             $reward->setWebsiteId($customer->getWebsiteId());
@@ -74,36 +84,51 @@ class RewardService implements RewardServiceInterface
     /**
      * Apply reward points to a quote.
      *
-     * @param int $points
      * @param CartInterface $quote
-     * @param CustomerInterface $customer
+     * @param int $customerId
      * @return void
      */
-	public function applyRewardPointsToQuote($points, CartInterface $quote, CustomerInterface $customer)
+	public function applyRewardPointsToQuote(CartInterface $quote, int $customerId)
 	{
 		try {
-			$this->logInfo('Applying ' . $points . ' reward points to quote ' . $quote->getId() . ' for customer ' . $customer->getId());
+            $customer = $this->customerRepository->getById($customerId);
+            $availablePoints = $this->getRewardPointsBalance($customer->getId());
+        
+            // Log the retrieved balance for debugging.
+            $this->logInfo('Retrieved ' . $availablePoints . ' reward points for customer ' . $customer->getCustomerEmail());
+    
+            // Define or retrieve a conversion rule
+            // TO-DO: Verify this path (reward/general/points_conversion_rate) is correct once we have access to the dev environment.
+            $conversionRate = $this->scopeConfig->getValue(
+                'reward/general/points_conversion_rate',
+                ScopeInterface::SCOPE_STORE
+            );
+            
+            // Convert quote total to points required
+            $pointsRequired = (int)round($quote->getGrandTotal() * $conversionRate);
+    
+            // Check if the customer has enough reward points
+            if ($pointsRequired > $availablePoints) {
+                throw new LocalizedException(__('Insufficient reward points.'));
+            }
+            
+            // Instead of taking points as a parameter, determine how many points to apply based on the quote
+            $pointsToApply = min($pointsRequired, $availablePoints);
+    
+            // Convert reward points to currency amount
+            $rewardAmount = $this->convertPointsToAmount($pointsToApply);
+    
+            // Apply the reward amount to the quote
+            $quote->setUseRewardPoints(true);
+            $quote->setRewardPointsBalance($pointsToApply); // The actual points applied
+            $quote->setRewardCurrencyAmount($rewardAmount);
+            $quote->setBaseRewardCurrencyAmount($rewardAmount);
+            $quote->collectTotals();
+    
+            // Save the quote to persist changes
+            $quote->save();
 	
-			// Check if the customer has enough reward points
-			$availablePoints = $this->getRewardPointsBalance($customer);
-			if ($points > $availablePoints) {
-				throw new LocalizedException(__('Insufficient reward points.'));
-			}
-	
-			// Convert reward points to currency amount
-			$rewardAmount = $this->convertPointsToAmount($points);
-	
-			// Apply the reward amount to the quote
-			$quote->setUseRewardPoints(true);
-			$quote->setRewardPointsBalance($availablePoints);
-			$quote->setRewardCurrencyAmount($rewardAmount);
-			$quote->setBaseRewardCurrencyAmount($rewardAmount);
-			$quote->collectTotals();
-	
-			// Save the quote
-			$quote->save();
-	
-			$this->logInfo('Successfully applied ' . $points . ' reward points to quote ' . $quote->getId());
+			$this->logInfo('Successfully applied ' . $pointsToApply . ' reward points to quote ' . $quote->getId());
 		} catch (Exception $e) {
 			$this->logError('Error applying reward points to quote: ' . $e->getMessage());
 			throw new LocalizedException(__('Could not apply reward points to the quote.'));
@@ -113,9 +138,9 @@ class RewardService implements RewardServiceInterface
 	protected function convertPointsToAmount($points)
     {
         // Retrieve the points conversion rate from the Magento configuration
-        // TO-DO: Verify this path (reward/general/points_money) is correct once we have access to the dev environment. 
+        // TO-DO: Verify this path (reward/general/points_money) is correct once we have access to the dev environment.
         $pointsValue = $this->scopeConfig->getValue(
-            'reward/general/points_money',
+            'reward/general/points_conversion_rate',
             ScopeInterface::SCOPE_STORE
         );
 

--- a/Service/RewardService.php
+++ b/Service/RewardService.php
@@ -1,7 +1,8 @@
 <?php
 
-namespace Instant\Checkout\Model;
+namespace Instant\Checkout\Service;
 
+use Exception;
 use Magento\Framework\Exception\LocalizedException;
 use Instant\Checkout\Api\RewardServiceInterface;
 use Magento\Framework\App\Config\ScopeConfigInterface;
@@ -86,7 +87,7 @@ class RewardService implements RewardServiceInterface
 			// Check if the customer has enough reward points
 			$availablePoints = $this->getRewardPointsBalance($customer);
 			if ($points > $availablePoints) {
-				throw new \Magento\Framework\Exception\LocalizedException(__('Insufficient reward points.'));
+				throw new LocalizedException(__('Insufficient reward points.'));
 			}
 	
 			// Convert reward points to currency amount
@@ -105,7 +106,7 @@ class RewardService implements RewardServiceInterface
 			$this->logInfo('Successfully applied ' . $points . ' reward points to quote ' . $quote->getId());
 		} catch (Exception $e) {
 			$this->logError('Error applying reward points to quote: ' . $e->getMessage());
-			throw new \Magento\Framework\Exception\LocalizedException(__('Could not apply reward points to the quote.'));
+			throw new LocalizedException(__('Could not apply reward points to the quote.'));
 		}
 	}
 	

--- a/Service/RewardService.php
+++ b/Service/RewardService.php
@@ -86,7 +86,7 @@ class RewardService implements RewardServiceInterface
      *
      * @param CartInterface $quote
      * @param int $customerId
-     * @return void
+     * @return bool
      */
 	public function applyRewardPointsToQuote(CartInterface $quote, int $customerId)
 	{
@@ -129,6 +129,8 @@ class RewardService implements RewardServiceInterface
             $quote->save();
 	
 			$this->logInfo('Successfully applied ' . $pointsToApply . ' reward points to quote ' . $quote->getId());
+            
+            return true;
 		} catch (Exception $e) {
 			$this->logError('Error applying reward points to quote: ' . $e->getMessage());
 			throw new LocalizedException(__('Could not apply reward points to the quote.'));

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -9,4 +9,9 @@
     <preference for="Instant\Checkout\Api\Data\RequestLogSearchResultsInterface"
         type="Magento\Framework\Api\SearchResults" />
     <!-- End request logger -->
+
+    <!-- Reward service -->
+    <preference for="Instant\Checkout\Api\RewardServiceInterface."
+        type="Instant\Checkout\Model\RewardService" />
+    <!-- End reward service -->
 </config>

--- a/etc/webapi.xml
+++ b/etc/webapi.xml
@@ -9,7 +9,7 @@
     </route>
     
     <!--  Get rewards point balance -->
-    <route url="/V1/instant/rewards/balance" method="GET">
+    <route url="/V1/instant/:customerId/rewards/balance" method="GET">
         <service class="Instant\Checkout\Api\RewardServiceInterface" method="getRewardPointsBalance"/>
         <resources>
             <resource ref="Magento_Customer::customer"/>
@@ -17,7 +17,7 @@
     </route>
     
     <!-- Apply rewards points to quote -->
-    <route url="/V1/instant/rewards/apply" method="POST">
+    <route url="/V1/instant/:customerId/rewards/apply" method="POST">
         <service class="Instant\Checkout\Api\RewardServiceInterface" method="applyRewardPointsToQuote"/>
         <resources>
             <resource ref="Magento_Customer::customer"/>

--- a/etc/webapi.xml
+++ b/etc/webapi.xml
@@ -8,17 +8,17 @@
         </resources>
     </route>
     
-    <!-- Apply rewards points to quote -->
-    <route url="/V1/rewards/apply" method="POST">
-        <service class="Instant\Checkout\Api\RewardServiceInterface" method="applyRewardPointsToQuote"/>
+    <!--  Get rewards point balance -->
+    <route url="/V1/instant/rewards/balance" method="GET">
+        <service class="Instant\Checkout\Api\RewardServiceInterface" method="getRewardPointsBalance"/>
         <resources>
             <resource ref="Magento_Customer::customer"/>
         </resources>
     </route>
     
-    <!--  Get rewards point balance -->
-    <route url="/V1/rewards/balance" method="GET">
-        <service class="Instant\Checkout\Api\RewardServiceInterface" method="getRewardPointsBalance"/>
+    <!-- Apply rewards points to quote -->
+    <route url="/V1/instant/rewards/apply" method="POST">
+        <service class="Instant\Checkout\Api\RewardServiceInterface" method="applyRewardPointsToQuote"/>
         <resources>
             <resource ref="Magento_Customer::customer"/>
         </resources>

--- a/etc/webapi.xml
+++ b/etc/webapi.xml
@@ -8,19 +8,19 @@
         </resources>
     </route>
     
-    <!--  Get rewards point balance -->
+    <!--  Get rewards point balance. TO-DO: We need to look at acl.xml to see what resource to use with OAuth -->
     <route url="/V1/instant/:customerId/rewards/balance" method="GET">
         <service class="Instant\Checkout\Api\RewardServiceInterface" method="getRewardPointsBalance"/>
         <resources>
-            <resource ref="Magento_Customer::customer"/>
+            <resource ref="any"/>
         </resources>
     </route>
     
-    <!-- Apply rewards points to quote -->
+    <!-- Apply rewards points to quote. TO-DO: We need to look at acl.xml to see what resource to use with OAuth -->
     <route url="/V1/instant/:customerId/rewards/apply" method="POST">
         <service class="Instant\Checkout\Api\RewardServiceInterface" method="applyRewardPointsToQuote"/>
         <resources>
-            <resource ref="Magento_Customer::customer"/>
+            <resource ref="any"/>
         </resources>
     </route>
 </routes>

--- a/etc/webapi.xml
+++ b/etc/webapi.xml
@@ -2,9 +2,25 @@
 <routes xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Webapi:etc/webapi.xsd">
     <route url="/V1/instant/:storeCode/cart/get-masked-id" method="POST">
-        <service class="Instant\Checkout\Api\CartsManagementInterface" method="getMaskedIdForCartId" />
+        <service class="Instant\Checkout\Api\CartsManagementInterface" method="getMaskedIdForCartId"/>
         <resources>
-            <resource ref="Magento_Cart::manage" />
+            <resource ref="Magento_Cart::manage"/>
+        </resources>
+    </route>
+    
+    <!-- Apply rewards points to quote -->
+    <route url="/V1/rewards/apply" method="POST">
+        <service class="Instant\Checkout\Api\RewardServiceInterface" method="applyRewardPointsToQuote"/>
+        <resources>
+            <resource ref="Magento_Customer::customer"/>
+        </resources>
+    </route>
+    
+    <!--  Get rewards point balance -->
+    <route url="/V1/rewards/balance" method="GET">
+        <service class="Instant\Checkout\Api\RewardServiceInterface" method="getRewardPointsBalance"/>
+        <resources>
+            <resource ref="Magento_Customer::customer"/>
         </resources>
     </route>
 </routes>


### PR DESCRIPTION
This PR is to enable the native magento rewards to be used with our merchants. 

As of this draft being raised, 20/03/2024, this is an untested and likely incomplete PR, as we have no enterprise environment to currently test this on.